### PR TITLE
feat: トップページのイベント表示個数制限

### DIFF
--- a/src/components/TopPage/EventList.tsx
+++ b/src/components/TopPage/EventList.tsx
@@ -22,7 +22,11 @@ export const EventList = () => {
       )}
       {eventList.map((event) => {
         return (
-          <EventCard key={event.id} name={event.name} eventId={event.id} />
+          <EventCard
+            key={event.id + event.name}
+            name={event.name}
+            eventId={event.id}
+          />
         );
       })}
     </Stack>

--- a/src/components/TopPage/EventList.tsx
+++ b/src/components/TopPage/EventList.tsx
@@ -3,13 +3,42 @@ import { useEffect, useState } from "react";
 import ListButton from "./ListButton";
 import { getEventStorage } from "@/libraries/eventStorage";
 import { IEvent } from "@/@types/api/event";
+import { VerticalCard } from "./VerticalCard";
+
+const FOLDING_EVENT_LIMIT = 3;
 
 export const EventList = () => {
   const [eventList, setEventList] = useState<IEvent[]>([]);
+  const [listPosition, setListPosition] = useState(0);
+
   useEffect(() => {
     if (typeof window !== "object") return;
     setEventList(getEventStorage());
   }, []);
+
+  /**
+   * イベントリストの位置の上下
+   * @param isUp
+   */
+  const handleChangeListPosition = (isUp: boolean) => {
+    isUp
+      ? setListPosition(listPosition - 1)
+      : setListPosition(listPosition + 1);
+  };
+
+  // 一定数以上のイベントがある場合は折りたたむ
+  const isNeedsFolding = eventList.length > FOLDING_EVENT_LIMIT;
+
+  // スタート・エンド位置
+  const startPosition = listPosition * FOLDING_EVENT_LIMIT;
+  const endPosition = startPosition + FOLDING_EVENT_LIMIT;
+
+  // スクロールアップ可能・スクロールダウン可能
+  const isScrollUp = isNeedsFolding && listPosition > 0;
+  const isScrollDown =
+    isNeedsFolding &&
+    (listPosition + 1) * FOLDING_EVENT_LIMIT < eventList.length;
+
   return (
     <Stack spacing={1.5}>
       {eventList.length === 0 && (
@@ -20,7 +49,10 @@ export const EventList = () => {
           ここにはまだなにもありません
         </Typography>
       )}
-      {eventList.map((event) => {
+      {isScrollUp ? (
+        <VerticalCard isUp onClick={handleChangeListPosition} />
+      ) : null}
+      {eventList.slice(startPosition, endPosition).map((event) => {
         return (
           <EventCard
             key={event.id + event.name}
@@ -29,6 +61,9 @@ export const EventList = () => {
           />
         );
       })}
+      {isScrollDown ? (
+        <VerticalCard isUp={false} onClick={handleChangeListPosition} />
+      ) : null}
     </Stack>
   );
 };

--- a/src/components/TopPage/VerticalCard.tsx
+++ b/src/components/TopPage/VerticalCard.tsx
@@ -1,0 +1,34 @@
+import { FC } from "react";
+import { Button } from "@mui/material";
+import { Stack } from "@mui/system";
+import KeyboardArrowDownIcon from "@mui/icons-material/KeyboardArrowDown";
+import KeyboardArrowUpIcon from "@mui/icons-material/KeyboardArrowUp";
+
+type Props = {
+  isUp: boolean;
+  onClick: (isUp: boolean) => void;
+};
+
+export const VerticalCard: FC<Props> = ({ isUp, onClick }) => {
+  return (
+    <Stack
+      sx={{
+        borderRadius: 2,
+        borderColor: "primary.main",
+        bgcolor: "white",
+      }}
+    >
+      <Button
+        onClick={() => {
+          onClick(isUp);
+        }}
+      >
+        {isUp ? (
+          <KeyboardArrowUpIcon fontSize="small" />
+        ) : (
+          <KeyboardArrowDownIcon fontSize="small" />
+        )}
+      </Button>
+    </Stack>
+  );
+};


### PR DESCRIPTION
## やった事
トップページにおいて
- mockデータでのkeyのエラー修正
- イベントの表示個数が一定数以上の場合に制限し、スクロールできるように修正
-[該当のNotion](https://www.notion.so/magi-sche/ddd1750510ca4aa6bb8797aed30c11ed?pvs=4)

## メモ
- とりあえずできるよぐらいの普通のデザイン
- リミットは3つです

## 変更結果
<img src="https://github.com/geekcamp-vol11-team30/frontend/assets/109256327/abafaee4-4149-4a07-9afd-08413157cd46" width="400px">

<img src="https://github.com/geekcamp-vol11-team30/frontend/assets/109256327/5680f28d-548a-4ce4-a413-941968fec78e" width="400px">
