### PR TITLE
feat: イベント作成画面の開始日・終了日のDateRangePickerの実装

### DIFF
--- a/src/@types/calender.d.ts
+++ b/src/@types/calender.d.ts
@@ -1,0 +1,18 @@
+import { Dayjs } from "dayjs";
+
+/**
+ * DatePicker上で使用するカレンダーの日付の型
+ *
+ * - day: Day.jsのオブジェクト
+ * - isThisMonthDay: 今月の日付
+ * - isStarted: 選択されている開始日
+ * - isEnded: 選択されている終了日
+ * - isBetween: 開始日と終了日の間
+ */
+export type CalenderItemType = {
+  day: Dayjs;
+  isThisMonthDay: boolean;
+  isStarted: boolean;
+  isEnded: boolean;
+  isBetween: boolean;
+};

--- a/src/components/EventMakePage/DateRangePicker/CalenderBody.tsx
+++ b/src/components/EventMakePage/DateRangePicker/CalenderBody.tsx
@@ -1,0 +1,49 @@
+import { FC } from "react";
+import { DayCell } from "./DayCell";
+import { CalenderItemType } from "@/@types/calender";
+import { Grid } from "@mui/material";
+import { Stack } from "@mui/system";
+import { Dayjs } from "dayjs";
+
+type Props = {
+  calenderArray: CalenderItemType[][];
+  handleSelectDay: (day: Dayjs) => void;
+  isUndefinedSelectedDay: boolean;
+};
+
+/**
+ * カレンダーの日付部分を表示
+ *
+ * @param calenderArray カレンダーのデータ
+ * @param handleSelectDay カレンダーの日付を選択した時のhandler
+ * @param isUndefinedSelectedDay 開始日・終了日が選択されているかどうか
+ */
+export const CalenderBody: FC<Props> = ({
+  calenderArray,
+  handleSelectDay,
+  isUndefinedSelectedDay,
+}) => {
+  return (
+    <Stack>
+      {calenderArray.map((week, index) => {
+        const key = week[index].day.format("YYYY-MM-DD");
+        return (
+          <Grid container key={key} justifyContent="center" columns={7}>
+            {week.map((day) => {
+              const key = day.day.format("YYYY-MM-DD");
+              return (
+                <Grid key={key} item xs={1}>
+                  <DayCell
+                    calenderItem={day}
+                    handleSelectDay={handleSelectDay}
+                    isUndefinedSelectedDay={isUndefinedSelectedDay}
+                  />
+                </Grid>
+              );
+            })}
+          </Grid>
+        );
+      })}
+    </Stack>
+  );
+};

--- a/src/components/EventMakePage/DateRangePicker/CalenderControlHeader.tsx
+++ b/src/components/EventMakePage/DateRangePicker/CalenderControlHeader.tsx
@@ -1,0 +1,55 @@
+import { Grid, Typography, IconButton } from "@mui/material";
+import { Stack } from "@mui/system";
+import { FC } from "react";
+import ArrowBackIosIcon from "@mui/icons-material/ArrowBackIos";
+import ArrowForwardIosIcon from "@mui/icons-material/ArrowForwardIos";
+
+type Props = {
+  headerLabel: string;
+  addMonth: () => void;
+  subtractMonth: () => void;
+};
+
+/**
+ * カレンダーの操作・表示部
+ *
+ * @param headerLabel 年月のラベル
+ * @param addMonth 月を進めるhandler
+ * @param subtractMonth 月を戻すhandler
+ */
+export const CalenderControlHeader: FC<Props> = ({
+  headerLabel,
+  addMonth,
+  subtractMonth,
+}) => {
+  return (
+    <Grid container columns={7} alignItems="center">
+      <Grid item xs={3}>
+        <Typography
+          variant="h6"
+          sx={{
+            ml: 2,
+          }}
+        >
+          {headerLabel}
+        </Typography>
+      </Grid>
+      <Grid item xs={2} />
+      <Grid item xs={2}>
+        <Stack
+          direction="row"
+          justifyContent="center"
+          alignItems="end"
+          spacing={2}
+        >
+          <IconButton onClick={subtractMonth}>
+            <ArrowBackIosIcon fontSize="small" />
+          </IconButton>
+          <IconButton onClick={addMonth}>
+            <ArrowForwardIosIcon fontSize="small" />
+          </IconButton>
+        </Stack>
+      </Grid>
+    </Grid>
+  );
+};

--- a/src/components/EventMakePage/DateRangePicker/CalenderHeader.tsx
+++ b/src/components/EventMakePage/DateRangePicker/CalenderHeader.tsx
@@ -14,7 +14,9 @@ export const CalenderHeader: FC = () => {
         return (
           <Grid key={item} item xs={1}>
             <Stack alignItems="center">
-              <Button sx={{ color: "black" }}>{item}</Button>
+              <Button size="small" sx={{ color: "black" }}>
+                {item}
+              </Button>
             </Stack>
           </Grid>
         );

--- a/src/components/EventMakePage/DateRangePicker/CalenderHeader.tsx
+++ b/src/components/EventMakePage/DateRangePicker/CalenderHeader.tsx
@@ -1,0 +1,24 @@
+import { Button, Grid } from "@mui/material";
+import { Stack } from "@mui/system";
+import { FC } from "react";
+
+const weekArray = ["日", "月", "火", "水", "木", "金", "土"];
+
+/**
+ * カレンダーの曜日の列の表示
+ */
+export const CalenderHeader: FC = () => {
+  return (
+    <Grid container justifyContent="center" columns={7}>
+      {weekArray.map((item) => {
+        return (
+          <Grid key={item} item xs={1}>
+            <Stack alignItems="center">
+              <Button sx={{ color: "black" }}>{item}</Button>
+            </Stack>
+          </Grid>
+        );
+      })}
+    </Grid>
+  );
+};

--- a/src/components/EventMakePage/DateRangePicker/DateRangePicker.tsx
+++ b/src/components/EventMakePage/DateRangePicker/DateRangePicker.tsx
@@ -1,0 +1,107 @@
+import { Stack } from "@mui/system";
+import { Dayjs } from "dayjs";
+import { FC } from "react";
+import { CalenderHeader } from "./CalenderHeader";
+import { CalenderBody } from "./CalenderBody";
+import { CalenderItemType } from "@/@types/calender";
+import { useCalenderControl } from "@/hooks/useCalenderControl";
+import { CalenderControlHeader } from "./CalenderControlHeader";
+import _isBetween from "dayjs/plugin/isBetween";
+
+type Props = {
+  startDay: Dayjs | undefined;
+  endDay: Dayjs | undefined;
+  setStartDay: (newValue: Dayjs | undefined) => void;
+  setEndDay: (newValue: Dayjs | undefined) => void;
+};
+
+/**
+ * 日付間の開始日・終了日をカレンダーから選択
+ *
+ * @param startDay 開始日
+ * @param endDay 終了日
+ * @param setStartDay 開始日を更新するhandler
+ * @param setEndDay 終了日を更新するhandler
+ */
+export const DateRangePicker: FC<Props> = ({
+  startDay,
+  endDay,
+  setStartDay,
+  setEndDay,
+}) => {
+  const { nowDate, dateArrayByWeek, addMonth, subtractMonth } =
+    useCalenderControl();
+
+  // startDay・endDayがどちらか一方が存在しない
+  const isUndefinedSelectedDay = startDay === undefined || endDay === undefined;
+
+  /**
+   * startDayとendDayの選択handler
+   * @param day 選択された日付
+   *
+   * - 開始日・終了日が既に存在する場合：開始日を設定し、終了日を削除
+   * - 開始日のみが存在する場合：終了日を設定
+   * - 終了日に開始日より前の日付が設定される場合：開始日と終了日を入れ替える
+   */
+  const handleSelectDay = (day: Dayjs) => {
+    if (!isUndefinedSelectedDay) {
+      setStartDay(day);
+      setEndDay(undefined);
+    } else if (endDay === undefined) {
+      if (day > startDay!) {
+        setEndDay(day);
+      } else {
+        setEndDay(startDay);
+        setStartDay(day);
+      }
+    }
+  };
+
+  /**
+   * CalenderItemTypeに変換する
+   * - isStarted: startDayでtrue
+   * - isEnded: endDayでtrue
+   * - isBetween: startDay < dayNumber < endDay でtrue
+   */
+  const calenderArray: CalenderItemType[][] = dateArrayByWeek.map(
+    (weekArray) => {
+      return weekArray.map((day) => {
+        const dayStr = day.format("YYYY-MM-DD");
+        const startDayStr = startDay?.format("YYYY-MM-DD") ?? "";
+        const endDayStr = endDay?.format("YYYY-MM-DD") ?? "";
+        const isUndefinedSelectedDay = startDayStr === "" || endDayStr === "";
+
+        const isThisMonthDay = day.month() === nowDate.month();
+        const isStarted = dayStr === startDayStr;
+        const isEnded = dayStr === endDayStr;
+        const isBetween = isUndefinedSelectedDay
+          ? false
+          : day.isBetween(startDay, endDay);
+
+        return {
+          day,
+          isThisMonthDay,
+          isStarted,
+          isEnded,
+          isBetween,
+        };
+      });
+    },
+  );
+
+  return (
+    <Stack justifyContent="center" spacing={1}>
+      <CalenderControlHeader
+        headerLabel={nowDate.format("YYYY年MM月")}
+        addMonth={addMonth}
+        subtractMonth={subtractMonth}
+      />
+      <CalenderHeader />
+      <CalenderBody
+        calenderArray={calenderArray}
+        handleSelectDay={handleSelectDay}
+        isUndefinedSelectedDay={isUndefinedSelectedDay}
+      />
+    </Stack>
+  );
+};

--- a/src/components/EventMakePage/DateRangePicker/DayCell.tsx
+++ b/src/components/EventMakePage/DateRangePicker/DayCell.tsx
@@ -82,6 +82,7 @@ export const DayCell: FC<Props> = ({
   };
 
   const stylesObj: SxProps<Theme> = {
+    minWidth: "50px",
     ...styles,
     "&:hover": {
       ...styles,

--- a/src/components/EventMakePage/DateRangePicker/DayCell.tsx
+++ b/src/components/EventMakePage/DateRangePicker/DayCell.tsx
@@ -1,0 +1,109 @@
+import { CalenderItemType } from "@/@types/calender";
+import { theme } from "@/theme/theme";
+import { Button, SxProps } from "@mui/material";
+import { Stack, Theme } from "@mui/system";
+import { Dayjs } from "dayjs";
+import { FC } from "react";
+
+const PRIMARYLIGHT = theme.palette.primary.light;
+
+type Props = {
+  calenderItem: CalenderItemType;
+  handleSelectDay: (day: Dayjs) => void;
+  isUndefinedSelectedDay: boolean;
+};
+
+/**
+ * カレンダーの日付部分の１マス
+ *
+ * @param calenderArray カレンダーのデータ
+ * @param handleSelectDay カレンダーの日付を選択した時のhandler
+ * @param isUndefinedSelectedDay 開始日・終了日が選択されているかどうか
+ */
+export const DayCell: FC<Props> = ({
+  calenderItem,
+  handleSelectDay,
+  isUndefinedSelectedDay,
+}) => {
+  const { day, isThisMonthDay, isStarted, isEnded, isBetween } = calenderItem;
+  const isSelected = isStarted || isEnded;
+
+  const bgcolor = (() => {
+    if (isSelected) {
+      return "primary.main";
+    }
+    if (isBetween) {
+      return "primary.light";
+    }
+    return "";
+  })();
+  const stackBgColor = (() => {
+    if (isBetween) {
+      return "primary.light";
+    }
+    return "";
+  })();
+  const borderRadius = (() => {
+    if (isUndefinedSelectedDay) {
+      return "100%";
+    }
+    if (isStarted) {
+      return "100%";
+    }
+    if (isEnded) {
+      return "100%";
+    }
+    return 0;
+  })();
+  const backgroundImage = (() => {
+    if (isUndefinedSelectedDay) {
+      return "";
+    }
+    if (isStarted) {
+      return `linear-gradient(to right, white 50%, ${PRIMARYLIGHT} 50%)`;
+    }
+    if (isEnded) {
+      return `linear-gradient(to right, ${PRIMARYLIGHT} 50%, white 50%)`;
+    }
+    return "";
+  })();
+  const color = isSelected ? "white" : "black";
+  const opacity = isThisMonthDay ? 1 : 0;
+  const disabled = !isThisMonthDay;
+  const zIndex = isSelected ? 1 : 0;
+
+  const styles: SxProps<Theme> = {
+    bgcolor: bgcolor,
+    color: color,
+    opacity: opacity,
+    borderRadius: borderRadius,
+    zIndex: zIndex,
+    aspectRatio: 1,
+  };
+
+  const stylesObj: SxProps<Theme> = {
+    ...styles,
+    "&:hover": {
+      ...styles,
+      opacity: opacity - 0.1,
+    },
+  };
+
+  const stackStyles: SxProps<Theme> = {
+    bgcolor: stackBgColor,
+    backgroundImage: backgroundImage,
+  };
+
+  return (
+    <Stack alignItems="center" sx={stackStyles}>
+      <Button
+        disabled={disabled}
+        sx={stylesObj}
+        size="small"
+        onClick={() => handleSelectDay(day)}
+      >
+        {day.format("D")}
+      </Button>
+    </Stack>
+  );
+};

--- a/src/components/EventMakePage/EventMakePageBody.tsx
+++ b/src/components/EventMakePage/EventMakePageBody.tsx
@@ -13,7 +13,7 @@ import {
 } from "@mui/material";
 import { Stack } from "@mui/system";
 import { useState } from "react";
-import { LocalizationProvider, MobileDatePicker } from "@mui/x-date-pickers";
+import { LocalizationProvider } from "@mui/x-date-pickers";
 import dayjs, { Dayjs } from "dayjs";
 import { AdapterDayjs } from "@mui/x-date-pickers/AdapterDayjs";
 import { Button } from "../Button";
@@ -21,12 +21,10 @@ import { ModalStyle } from "../ModalStyle";
 import ContentCopyOutlinedIcon from "@mui/icons-material/ContentCopyOutlined";
 import { useRouter } from "next/router";
 import { useSnackbar } from "notistack";
-import { setEventStorage } from "@/libraries/eventStorage";
-import { createProposedStartTimeList } from "@/libraries/proposedStartTime";
-import { createEvent } from "@/libraries/api/events";
 import { PageTitle } from "../common/PageTitle";
 import { TimeSelect } from "./TimeSelect";
 import { IEventTimeDuration } from "@/@types/api/event";
+import { DateRangePicker } from "./DateRangePicker/DateRangePicker";
 
 type EventTimeLengthType = {
   value: IEventTimeDuration;
@@ -43,15 +41,17 @@ const EventMakePageBody: React.FC = () => {
   const [EventTimeDuration, setEventTimeDuration] = useState<number>(1800);
   // 日付
   const [StartDay, setStartDay] = useState<Dayjs | undefined>(dayjs());
-  const [EndDay, setEndDay] = useState<Dayjs | undefined>(dayjs().add(2, "h"));
+  const [EndDay, setEndDay] = useState<Dayjs | undefined>(
+    dayjs().add(3, "day"),
+  );
   // モーダル
   const [ModalOpen, setModalOpen] = useState<boolean>(false);
   const { enqueueSnackbar } = useSnackbar();
 
   const [shareURL, setShareURL] = useState("");
-  const handleStartDay = (newValue: Dayjs | null) => {
+  const handleStartDay = (newValue: Dayjs | undefined) => {
     setStartDay(newValue || undefined);
-    if (newValue != null && EndDay != null) {
+    if (newValue != undefined && EndDay != undefined) {
       // 開始日より終了日が小さければ開始日で終了日を更新
       if (newValue > EndDay) {
         setEndDay(newValue);
@@ -59,9 +59,9 @@ const EventMakePageBody: React.FC = () => {
     }
   };
 
-  const handleEndDay = (newValue: Dayjs | null) => {
+  const handleEndDay = (newValue: Dayjs | undefined) => {
     setEndDay(newValue || undefined);
-    if (newValue != null && StartDay != null) {
+    if (newValue != undefined && StartDay != undefined) {
       // 終了より開始日が小さければ開始日で終了日を更新
       if (newValue < StartDay) {
         setStartDay(newValue);
@@ -166,24 +166,13 @@ const EventMakePageBody: React.FC = () => {
         {/* 日付ピッカー */}
         <Stack spacing={3}>
           <Divider />
-
           <LocalizationProvider dateAdapter={AdapterDayjs}>
-            <Stack>
-              <Typography>開始日</Typography>
-              <MobileDatePicker
-                format="YYYY/MM/DD"
-                value={StartDay}
-                onChange={handleStartDay}
-              />
-            </Stack>
-            <Stack>
-              <Typography>終了日</Typography>
-              <MobileDatePicker
-                format="YYYY/MM/DD"
-                value={EndDay}
-                onChange={handleEndDay}
-              />
-            </Stack>
+            <DateRangePicker
+              startDay={StartDay}
+              endDay={EndDay}
+              setStartDay={handleStartDay}
+              setEndDay={handleEndDay}
+            />
           </LocalizationProvider>
         </Stack>
         <Divider />

--- a/src/hooks/useCalenderControl.ts
+++ b/src/hooks/useCalenderControl.ts
@@ -1,0 +1,55 @@
+import dayjs, { Dayjs } from "dayjs";
+import { useState } from "react";
+
+type CalenderControlType = {
+  nowDate: Dayjs;
+  dateArrayByWeek: Dayjs[][];
+  addMonth: () => void;
+  subtractMonth: () => void;
+};
+
+/**
+ * カレンダーの表示を管理するhooks
+ *
+ * @returns nowDate：Day.jsのインスタンス
+ * @returns dateArrayBeWeek：Dayjsの1ヶ月分の配列
+ * @returns addMonth：カレンダーを1月後ろに進める
+ * @returns subtractMonth:カレンダーを1月前に戻す
+ */
+export const useCalenderControl = (): CalenderControlType => {
+  const [MonthPosition, setMonthPosition] = useState<number>(0);
+  const dayObj = dayjs().startOf("month").add(MonthPosition, "month");
+  const nowDate = dayObj;
+
+  // 当月の最初の日付の曜日（位置 0~6）
+  const firstDatePosition = dayObj.startOf("month").day();
+  // 当月の最後の日付
+  const lastDate = dayObj.endOf("month").date();
+  // 当月の週の数
+  const weekCount = Math.ceil((lastDate + firstDatePosition) / 7);
+
+  // その月のカレンダーの最初から最後までの日付を配列に格納
+  const dateArray = [...Array(weekCount * 7)].map((_, index) => {
+    return index < firstDatePosition
+      ? dayObj.subtract(firstDatePosition - index, "day")
+      : dayObj.add(index - firstDatePosition, "day");
+  });
+  // 7日ごとに配列に格納する
+  const dateArrayByWeek = [...Array(weekCount)].map((_, index) => {
+    return dateArray.slice(index * 7, (index + 1) * 7);
+  });
+
+  /**
+   * 月を前後させる
+   * - addMonth: 1ヶ月後
+   * - subtractMonth: 1ヶ月前
+   */
+  const addMonth = () => {
+    setMonthPosition(MonthPosition + 1);
+  };
+  const subtractMonth = () => {
+    setMonthPosition(MonthPosition - 1);
+  };
+
+  return { nowDate, dateArrayByWeek, addMonth, subtractMonth };
+};

--- a/src/theme/palette.ts
+++ b/src/theme/palette.ts
@@ -3,7 +3,7 @@ import { PaletteOptions } from "@mui/material";
 export const palette: PaletteOptions = {
   primary: {
     main: "#006A71",
-    light: "#46989F",
+    light: "#D1DAC9",
   },
   secondary: {
     main: "#FFFFDD",


### PR DESCRIPTION
## やったこと
- イベント作成画面の開始日・終了日のDateRangePickerの実装
- 値のハンドリング

## メモ
- ドラッグして選択できるようには時間があったらしようの気持ちです

## スクリーンショット
<img width="400px" src="https://github.com/geekcamp-vol11-team30/frontend/assets/109256327/f4246398-5a16-4650-9dc1-07760efb0d22">
